### PR TITLE
feat: use new dockerhub account

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 ```bash
 mkdir project-nrf-C12880MA-motherboard_west
 cd project-nrf-C12880MA-motherboard_west
-docker run --rm -it -u $(id -u):$(id -g) -v $(pwd):/workdir/project nrfassettracker/nrfconnect-sdk:v1.9-branch \
+docker run --rm -it -u $(id -u):$(id -g) -v $(pwd):/workdir/project nordicplayground/nrfconnect-sdk:v1.9-branch \
   bash -c "west init -m https://github.com/fgervais/project-nrf-C12880MA-motherboard.git . && west update"
 ```
 
 ### Add Thread network key
 
-Add `secret.conf` in the `app` folder with content like this which matches your 
+Add `secret.conf` in the `app` folder with content like this which matches your
 network key:
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   nrf:
-    image: nrfassettracker/nrfconnect-sdk:v1.9-branch
+    image: nordicplayground/nrfconnect-sdk:v1.9-branch
     user: ${UID:-1000}:${GID:-1000}
     volumes:
       - ..:/workdir/project


### PR DESCRIPTION
The Docker image is now published under the
nordicplayground Dockerhub account
